### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ PHONEY := build
 build: module/vangogh_oc_fix.ko.xz
 
 $(HEADERS_BUILD):
-	$(error "Could not find $(HEADERS_BUILD)\nYou probably don't have headers installed. Run 'sudo pacman -S $(PKGBASE)-headers' to install them")
+	$(error "Could not find $(HEADERS_BUILD). You probably don't have headers installed. Run 'sudo pacman -Ss linux-neptune' to find which linux header package to install")
 
 PHONEY += clean
 clean: $(HEADERS_DIR)


### PR DESCRIPTION
$(PKGBASE) doesn't resolve because it's not defined in the code.
It doesn't help us anyway, the linux header packages in SteamOS are 'non standard', you would expect them all to be included in 'linux-headers'?
In fact, they are not. They are stored in packages named similar but not exactly to the steamOS version name. Instead we should tell people in the error/warning message to search for the version themselves and make an educated guess based on our output of where we expected the headers to be found.

For example at the time of writing, the correct header package would be:

jupiter-3.5/linux-neptune-61-headers